### PR TITLE
Handle non existant profiles

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "axios": "^1.6.5",
     "browser-image-compression": "^2.0.2",
     "child_process": "^1.0.2",
     "downloadjs": "^1.4.7",

--- a/src/app/api/retrieve-profile-pic/route.ts
+++ b/src/app/api/retrieve-profile-pic/route.ts
@@ -1,5 +1,5 @@
 import { SocialPlatform } from "@/types";
-import axios from "axios";
+import axios, { AxiosError } from "axios";
 import { NextResponse, type NextRequest } from 'next/server';
 
 export async function GET(request: NextRequest) {
@@ -23,21 +23,34 @@ export async function GET(request: NextRequest) {
             break;
     }
 
+    if (profilePicUrl === null) {
+        return NextResponse.json({}, { status: 404 });
+    }
     return NextResponse.json({ profilePicUrl }, { status: 200 });
 }
 
 
 const fetchTwitterProfilePic = async (username: string) => {
     const endpoint = `https://api.fxtwitter.com/${username}`
-    const response = await axios.get(endpoint);
-    const smallImageUrl = response.data.user.avatar_url;
+    try {
+        const response = await axios.get(endpoint);
 
-    return smallImageUrl.replace('_normal', '_400x400');
+        const smallImageUrl = response.data.user.avatar_url;
+
+        return smallImageUrl.replace('_normal', '_400x400');
+    } catch (error) {
+        return null;
+    }
 }
 
 const fetchGithubProfilePic = async (username: string) => {
     const endpoint = `https://api.github.com/users/${username}`
-    const response = await axios.get(endpoint);
+    try {
+        const response = await axios.get(endpoint);
 
-    return response.data.avatar_url;
+        return response.data.avatar_url;
+    } catch (error) {
+        return null;
+    }
+
 }

--- a/src/app/api/retrieve-profile-pic/route.ts
+++ b/src/app/api/retrieve-profile-pic/route.ts
@@ -1,5 +1,5 @@
 import { SocialPlatform } from "@/types";
-import axios from "axios";
+import axios, { AxiosError } from "axios";
 import { NextResponse, type NextRequest } from 'next/server';
 
 export async function GET(request: NextRequest) {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next'
 import { Inter } from 'next/font/google'
-
 import './globals.css'
+import Script from 'next/script'
 
 const inter = Inter({ subsets: ['latin'] })
 
@@ -24,6 +24,20 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
+      <Script
+        id="hockeystack"
+        dangerouslySetInnerHTML={{
+          __html: `
+var hsscript = document.createElement("script");
+hsscript.src = "https://cdn.jsdelivr.net/npm/hockeystack@latest/hockeystack.min.js";
+hsscript.async = 1;
+hsscript.dataset.apikey = "${process.env.NEXT_PUBLIC_HOCKEYSTACK_API_KEY}";
+hsscript.dataset.cookieless = 1;
+hsscript.dataset.autoIdentify = 1;
+document.getElementsByTagName('head')[0].append(hsscript);
+                    `,
+        }}
+      />
       <body className={inter.className}>{children}</body>
     </html>
   )

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -44,7 +44,9 @@ export default function Home() {
         const response = await axios.get(`/api/retrieve-profile-pic?username=${userProvidedUsername}&platform=${platform}`);
         setUserImageUrl(response.data.profilePicUrl);
       } catch (error) {
-        console.error('Error fetching twitter profile picture:', error);
+        const capitalizedPlatform = platform.charAt(0).toUpperCase() + platform.slice(1);
+        alert(`Error fetching your ${capitalizedPlatform} profile picture. Please make sure you entered a correct username.`);
+        console.error(`Error fetching ${capitalizedPlatform} profile picture:`, error);
       }
     }
   };

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,6 @@
 'use client'
 import { SocialPlatform } from '@/types';
+import axios from 'axios';
 import download from 'downloadjs';
 import { toPng } from 'html-to-image';
 import { useEffect, useRef, useState } from "react";
@@ -40,8 +41,8 @@ export default function Home() {
 
     if (userProvidedUsername) {
       try {
-        const response = await fetch(`/api/retrieve-profile-pic?username=${userProvidedUsername}&platform=${platform}`).then(res => res.json())
-        setUserImageUrl(response.profilePicUrl);
+        const response = await axios.get(`/api/retrieve-profile-pic?username=${userProvidedUsername}&platform=${platform}`);
+        setUserImageUrl(response.data.profilePicUrl);
       } catch (error) {
         const capitalizedPlatform = platform.charAt(0).toUpperCase() + platform.slice(1);
         alert(`Error fetching your ${capitalizedPlatform} profile picture. Please make sure you entered a correct username.`);


### PR DESCRIPTION
## Problem:
When the provided Github or Twitter profile doesn't exist, GET /api/retrieve-profile-pic returns a 500 error, and the user is not notified about anything.

## Solution:
The API call now returns a 404 error in this scenario, and an alert is displayed to the user with the following text: "Error fetching your <PLATFORM> profile picture. Please make sure you entered a correct username."