### PR TITLE
Handle inexistant profiles

### DIFF
--- a/src/app/api/retrieve-profile-pic/route.ts
+++ b/src/app/api/retrieve-profile-pic/route.ts
@@ -23,20 +23,32 @@ export async function GET(request: NextRequest) {
             break;
     }
 
+    if (profilePicUrl === null) {
+        return NextResponse.json({}, { status: 404 });
+    }
+
     return NextResponse.json({ profilePicUrl }, { status: 200 });
 }
 
 
 const fetchTwitterProfilePic = async (username: string) => {
-    const endpoint = `https://api.fxtwitter.com/${username}`
-    const response = await fetch(endpoint).then(res => res.json())
+    const endpoint = `https://api.fxtwitter.com/${username}`;
+    const response = await fetch(endpoint).then(res => res.ok ? res.json() : null);
+
+    if (response === null) {
+        return null
+    }
     const smallImageUrl = response.user.avatar_url;
 
     return smallImageUrl.replace('_normal', '_400x400');
 }
 
 const fetchGithubProfilePic = async (username: string) => {
-    const endpoint = `https://api.github.com/users/${username}`
-    const response = await fetch(endpoint).then(res => res.json())
+    const endpoint = `https://api.github.com/users/${username}`;
+    const response = await fetch(endpoint).then(res => res.ok ? res.json() : null);
+
+    if (response === null) {
+        return null;
+    }
     return response.avatar_url;
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -40,7 +40,11 @@ export default function Home() {
 
     if (userProvidedUsername) {
       try {
-        const response = await fetch(`/api/retrieve-profile-pic?username=${userProvidedUsername}&platform=${platform}`).then(res => res.json())
+        const response = await fetch(`/api/retrieve-profile-pic?username=${userProvidedUsername}&platform=${platform}`).then(res => res.ok ? res.json() : null);
+        if (response === null) {
+          alert('Error fetching your profile picture. Please make sure that you entered a correct username.');
+          return;
+        }
         setUserImageUrl(response.profilePicUrl);
       } catch (error) {
         console.error('Error fetching twitter profile picture:', error);


### PR DESCRIPTION
## Problem:
When the provided Github or Twitter profile doesn't exist, GET /api/retrieve-profile-pic returns a 500 error, and the user is not notified about anything.

## Solution:
The API call now returns a 404 error in this scenario, and an alert is displayed to the user with the following text: "Error fetching your <PLATFORM> profile picture. Please make sure you entered a correct username."