### PR TITLE
fix: downloaded picture not updating after start over

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -122,7 +122,7 @@ export default function Home() {
                   className="object-cover rounded-full cursor-wait"
                 />
               ) : (
-                <Image
+                <img
                   id="userImage"
                   alt="profile-image"
                   src={userImageUrl ?? '/user.jpg'}


### PR DESCRIPTION
# Bug reproduction step:

1. Use GitHub profile pic
2. Download it
3. Start over
4. Use X profile pic
5. Download it 
6. You get the previously entered GitHub profile pic

Using the native img tag for the profile pic instead of Next's Image solves it.

# Possible causes:

I don't know. I used the debugger step by step and it seems that the state is updated correctly. And at the time of the download, the rendered img has the correct src.

## Tested on the following browsers:
- Microsoft Edge
- Samsung Internet
