### PR TITLE
Add window reload to `startOver()` function

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -82,8 +82,8 @@ export default function Home() {
     }
   };
 
-  const startOver = async () => {
-    setUserImageUrl(undefined);
+  const startOver = () => {
+    window.location.reload();
   };
 
   return (


### PR DESCRIPTION
This should fix #22, removing the need for the repeated calls to `generateImage()` when profile pictures are downloaded.