### PR TITLE
feat: add mastodon profile pic

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -14,6 +14,12 @@ const nextConfig = {
       {
         hostname: 'gitlab.com',
       },
+      {
+        protocol: 'https',
+        // todo this does not work. is it possible to include all mastodon servers...
+        hostname: '**',
+        pathname: '/**/account/avatar/**',
+      },
     ],
   },
 };

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,6 +10,7 @@ import {
   FaGithub,
   FaGitlab,
   FaXTwitter,
+  FaMastodon,
 } from 'react-icons/fa6';
 
 export default function Home() {
@@ -60,13 +61,23 @@ export default function Home() {
 
   const handleRetrieveProfilePicture = async (platform: SocialPlatform) => {
     const userProvidedUsername = prompt(`Enter your ${platform} username:`);
+    const userProvidedServername =
+      platform == SocialPlatform.Mastodon
+        ? prompt(`Enter your ${platform} servername:`)
+        : null;
 
-    if (userProvidedUsername) {
+    if (
+      (userProvidedUsername && platform != SocialPlatform.Mastodon) ||
+      // mastodon needs a servername and a username
+      (platform == SocialPlatform.Mastodon &&
+        userProvidedServername &&
+        userProvidedUsername)
+    ) {
       setFilePostfix(platform);
       try {
         setLoader(true);
         const response = await fetch(
-          `/api/retrieve-profile-pic?username=${userProvidedUsername}&platform=${platform}`,
+          `/api/retrieve-profile-pic?username=${userProvidedUsername}&platform=${platform}&servername=${userProvidedServername}`,
         ).then((res) => (res.ok ? res.json() : null));
         setLoader(false);
         if (response === null) {
@@ -251,6 +262,14 @@ export default function Home() {
                 className="rounded-full my-2 py-3 px-2 w-full border border-gray-900 text-xl"
               >
                 Use <FaGitlab className="inline mb-1" /> Profile Pic
+              </button>
+              <button
+                onClick={async () =>
+                  await handleRetrieveProfilePicture(SocialPlatform.Mastodon)
+                }
+                className="rounded-full my-2 py-3 px-2 w-full border border-gray-900 text-xl"
+              >
+                Use <FaMastodon className="inline mb-1" /> Profile Pic
               </button>
             </>
           )}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,4 +2,5 @@ export enum SocialPlatform {
   Twitter = 'twitter',
   Github = 'github',
   Gitlab = 'gitlab',
+  Mastodon = 'Mastodon',
 }


### PR DESCRIPTION
**Feature**: use mastodon profile pic.

**Behavior**: user is prompt to add their username, then server name.

**Limitations**:
- Nextjs.config has the allowed remote hosts for the Image src, we cannot possibly count all mastodon servers as every server host their own avatars. **(ideas are welcome here!)**
- Avatar url is pulled from the server API, some documentations mention that it can be private info based on the server itself. but then it would return an error and we move on.