### PR TITLE
feat: customize border thickness

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,3 +1,28 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer utilities {
+    .slider-thumb {
+        @apply appearance-none w-full h-2 rounded-lg bg-gray-200 cursor-pointer;
+    }
+
+    .slider-thumb::-webkit-slider-thumb {
+        @apply w-5 h-5 bg-gray-800 hover:bg-gray-600 rounded-full cursor-pointer border-none;
+    }
+
+    .slider-thumb::-moz-range-thumb {
+        @apply w-5 h-5 bg-gray-800 hover:bg-gray-600 rounded-full cursor-pointer border-none;
+    }
+
+    /* Larger thumb size for mobile devices */
+    @media (max-width: 768px) {
+        .slider-thumb::-webkit-slider-thumb {
+            @apply w-7 h-7;
+        }
+
+        .slider-thumb::-moz-range-thumb {
+            @apply w-7 h-7;
+        }
+    }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -22,6 +22,7 @@ export default function Home() {
   const [filePostfix, setFilePostfix] = useState<
     SocialPlatform | 'user-upload'
   >();
+  const [borderThickness, setBorderThickness] = useState(15);
 
   useEffect(() => {
     const isInstagramBrowser = /Instagram/i.test(navigator.userAgent);
@@ -104,6 +105,7 @@ export default function Home() {
 
   const startOver = async () => {
     setUserImageUrl(undefined);
+    setBorderThickness(15);
   };
 
   return (
@@ -166,10 +168,10 @@ export default function Home() {
                   height={100}
                   style={{
                     position: 'absolute',
-                    width: '85%',
-                    height: '85%',
-                    left: '7.5%',
-                    top: '7.5%',
+                    width: `${100 - borderThickness}%`,
+                    height: `${100 - borderThickness}%`,
+                    left: `${borderThickness / 2}%`,
+                    top: `${borderThickness / 2}%`,
                   }}
                   className="object-cover rounded-full cursor-wait"
                 />
@@ -182,16 +184,34 @@ export default function Home() {
                   height={100}
                   style={{
                     position: 'absolute',
-                    width: '85%',
-                    height: '85%',
-                    left: '7.5%',
-                    top: '7.5%',
+                    width: `${100 - borderThickness}%`,
+                    height: `${100 - borderThickness}%`,
+                    left: `${borderThickness / 2}%`,
+                    top: `${borderThickness / 2}%`,
                   }}
                   className="object-cover rounded-full cursor-pointer"
                 />
               )}
             </div>
           </div>
+        </div>
+        <div className="my-4">
+          <label
+            htmlFor="borderRange"
+            className="block text-xs font-normal text-gray-500 mb-2"
+          >
+            Border Thickness: <span>{borderThickness}%</span>
+          </label>
+          <input
+            id="borderRange"
+            type="range"
+            min="5"
+            max="25"
+            step="1"
+            value={borderThickness}
+            onChange={(e) => setBorderThickness(parseInt(e.target.value))}
+            className="slider-thumb"
+          />
         </div>
         <div>
           {userImageUrl ? (


### PR DESCRIPTION
### Proposal

Thought about this feature (customizing the thickness of the border), but it's debatable as it might seem to defy the purpose of unifying the profile pictures. So please share your opinion.

### Demo:
https://github.com/user-attachments/assets/957dfff7-8715-43b2-b11d-8dde817e4602

### Design:

- I might have went a bit too much with the slider thumb design... I rather the black one, but thought to drop this as an option:
<img src=https://github.com/user-attachments/assets/cd7af05c-fb61-4e7b-af5a-afb1ee0d6abe width=200 />
<img src=https://github.com/user-attachments/assets/58b74e5b-195e-404c-b828-b4a1c87efcc1 width=200 />

- Let me know if the slider is nicer somewhere else on the page.
