### PR TITLE
Track end-to-end photo funnel in Plausible

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,5 @@
 'use client';
+import { FunnelEvent, trackEvent } from '@/lib/analytics';
 import { SocialPlatform } from '@/types';
 import download from 'downloadjs';
 import { toPng } from 'html-to-image';
@@ -24,6 +25,20 @@ export default function Home() {
   >();
 
   useEffect(() => {
+    trackEvent(FunnelEvent.Landed);
+  }, []);
+
+  // Step 4: a usable image source (data URL / social profile URL) is obtained.
+  useEffect(() => {
+    if (userImageUrl) {
+      trackEvent(FunnelEvent.PhotoFetched, {
+        method: filePostfix ?? 'unknown',
+      });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [userImageUrl]);
+
+  useEffect(() => {
     const isInstagramBrowser = /Instagram/i.test(navigator.userAgent);
     const isFacebookBrowser = /FBAN|FBAV/i.test(navigator.userAgent);
 
@@ -43,6 +58,7 @@ export default function Home() {
     const reader = new FileReader();
 
     if (file) {
+      trackEvent(FunnelEvent.PhotoProvided, { method: 'user-upload' });
       reader.onload = async (event: ProgressEvent<FileReader>) => {
         setFilePostfix('user-upload');
         setUserImageUrl(event.target?.result as string);
@@ -56,13 +72,16 @@ export default function Home() {
   };
 
   const handleUploadButtonClick = () => {
+    trackEvent(FunnelEvent.SourceSelected, { method: 'user-upload' });
     document.getElementById('fileInput')?.click();
   };
 
   const handleRetrieveProfilePicture = async (platform: SocialPlatform) => {
+    trackEvent(FunnelEvent.SourceSelected, { method: platform });
     const userProvidedUsername = prompt(`Enter your ${platform} username:`);
 
     if (userProvidedUsername) {
+      trackEvent(FunnelEvent.PhotoProvided, { method: platform });
       setFilePostfix(platform);
       try {
         setLoader(true);
@@ -99,10 +118,14 @@ export default function Home() {
     const generatedImageUrl = await generateImage();
     if (generatedImageUrl) {
       download(generatedImageUrl, `profile-pic-${filePostfix}.png`);
+      trackEvent(FunnelEvent.Downloaded, {
+        method: filePostfix ?? 'unknown',
+      });
     }
   };
 
   const startOver = async () => {
+    trackEvent(FunnelEvent.StartOver, { method: filePostfix ?? 'unknown' });
     setUserImageUrl(undefined);
   };
 
@@ -178,6 +201,14 @@ export default function Home() {
                   id="userImage"
                   alt="profile-image"
                   src={userImageUrl ?? '/user.jpg'}
+                  onLoad={() => {
+                    // Only the user's selected photo counts, not the placeholder.
+                    if (userImageUrl) {
+                      trackEvent(FunnelEvent.PreviewShown, {
+                        method: filePostfix ?? 'unknown',
+                      });
+                    }
+                  }}
                   width={100}
                   height={100}
                   style={{

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,45 @@
+type PlausibleProps = Record<string, string | number | boolean>;
+
+declare global {
+  interface Window {
+    plausible?: (
+      event: string,
+      options?: { props?: PlausibleProps; callback?: () => void },
+    ) => void;
+  }
+}
+
+/**
+ * Funnel events tracked end to end in Plausible, in firing order. The
+ * numeric prefix keeps them ordered in the Plausible dashboard.
+ *
+ * Landed: visitor opens the page.
+ * SourceSelected: clicks a "pick a photo" button (upload or a social platform).
+ * PhotoProvided: commits input (chooses a file / submits a username).
+ * PhotoFetched: a usable source is obtained (data URL / social profile URL).
+ * PreviewShown: that photo actually renders on screen.
+ * Downloaded: the final framed image is downloaded.
+ */
+export const FunnelEvent = {
+  Landed: 'Funnel: 1 Landed',
+  SourceSelected: 'Funnel: 2 Source Selected',
+  PhotoProvided: 'Funnel: 3 Photo Provided',
+  PhotoFetched: 'Funnel: 4 Photo Fetched',
+  PreviewShown: 'Funnel: 5 Preview Shown',
+  Downloaded: 'Funnel: 6 Downloaded',
+  // Not a funnel step: user resets to pick a different photo.
+  StartOver: 'Start Over',
+} as const;
+
+export type FunnelEventName = (typeof FunnelEvent)[keyof typeof FunnelEvent];
+
+/**
+ * Safely fire a Plausible custom event. No-ops during SSR or if the
+ * Plausible script hasn't loaded yet.
+ */
+export function trackEvent(event: FunnelEventName, props?: PlausibleProps) {
+  if (typeof window === 'undefined' || typeof window.plausible !== 'function') {
+    return;
+  }
+  window.plausible(event, props ? { props } : undefined);
+}


### PR DESCRIPTION
## What

Instruments the full conversion funnel as Plausible custom events so it can be monitored end to end. Events are numbered so they stay ordered in the Plausible dashboard:

| # | Event | Fires when |
|---|-------|-----------|
| 1 | `Funnel: 1 Landed` | visitor opens the page |
| 2 | `Funnel: 2 Source Selected` | clicks a "pick a photo" button (upload or a social platform) |
| 3 | `Funnel: 3 Photo Provided` | chooses a file / submits a username |
| 4 | `Funnel: 4 Photo Fetched` | a usable source is obtained (data URL / social profile URL) |
| 5 | `Funnel: 5 Preview Shown` | the photo actually renders on screen |
| 6 | `Funnel: 6 Downloaded` | the final framed image is downloaded |

Plus a non-funnel **`Start Over`** event when a user resets to pick a different photo.

Every event past step 1 carries a `method` prop (`user-upload`, `twitter`, `github`, `gitlab`, `bluesky`) so drop-off can be segmented by photo source.

Steps 4 and 5 are deliberately distinct and catch different failure modes:
- **3 → 4** drop-off: social fetch returned nothing / file read failed (no usable source).
- **4 → 5** drop-off: a source URL was obtained but the image is broken (404 / CORS / decode error) and never renders.

## How

- New typed helper `src/lib/analytics.ts` exposing a `FunnelEvent` map and a safe `trackEvent()` wrapper that no-ops during SSR and before the Plausible script has loaded.
- Wired the events into the photo flow in `src/app/page.tsx`.

## Setting up the funnel in Plausible

In the Plausible dashboard (Settings → Funnels), create a funnel from the six numbered custom-event goals, in order, to visualize end-to-end conversion and per-step drop-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)