### PR TITLE
Restructure Dependabot updates and refine CODEOWNERS configuration

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,27 +1,23 @@
-# Code owners — auto-requests review on matching paths.
+# Code owners: auto-requests review on matching paths.
 #
 # Dependency and CI-config changes (including Dependabot PRs) are routed to the
-# team that maintains THIS repository, so whoever maintains profile-pic-maker is
-# added as a reviewer — not the whole org.
+# repo owner so they get a review request automatically.
 #
-# Replace the slug below with the real team that has maintain/admin on this repo.
-# (If no such team exists, an org owner can create one, e.g.
-# "profile-pic-maker-maintainers", and grant it Maintain on this repo. As a
-# stop-gap you may instead list individual maintainer usernames: `@alice @bob`.)
-#
-# NOTE: team ownership (`@org/team`) only resolves on a repo owned by that org.
-# On a personal-account fork it is inert — it takes effect once this file lands
-# on the TechForPalestine org repo.
+# TEMPORARY (fork): set to @mostafazh so this validates on the personal-account
+# fork. When this file lands on the TechForPalestine org repo, replace @mostafazh
+# with the team that maintains this repo, e.g. @TechForPalestine/profile-pic-maker-maintainers
+# (an org owner can create that team and grant it Maintain), so review routes to
+# the repo's maintainers rather than a single person.
 
 # Dependency manifests & lockfile
-/package.json          @TechForPalestine/profile-pic-maker-maintainers
-/package-lock.json     @TechForPalestine/profile-pic-maker-maintainers
-/.npmrc                @TechForPalestine/profile-pic-maker-maintainers
+/package.json          @mostafazh
+/package-lock.json     @mostafazh
+/.npmrc                @mostafazh
 
 # CI, Dependabot, and repo automation
-/.github/              @TechForPalestine/profile-pic-maker-maintainers
+/.github/              @mostafazh
 
 # Toolchain / runtime version pins
-/.nvmrc                @TechForPalestine/profile-pic-maker-maintainers
-/devbox.json           @TechForPalestine/profile-pic-maker-maintainers
-/devbox.lock           @TechForPalestine/profile-pic-maker-maintainers
+/.nvmrc                @mostafazh
+/devbox.json           @mostafazh
+/devbox.lock           @mostafazh

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,23 @@
+# Code owners — auto-requests review on matching paths.
+#
+# Dependency and CI-config changes (including Dependabot PRs) are routed to the
+# maintainer TEAM rather than any single person, so whoever is on the team is
+# added as a reviewer. Replace the team slug below with the real one on the
+# upstream org if it differs.
+#
+# NOTE: team ownership (`@org/team`) only resolves on a repo owned by that org.
+# On a personal-account fork it is inert — it takes effect once this file lands
+# on the TechForPalestine org repo.
+
+# Dependency manifests & lockfile
+/package.json          @TechForPalestine/maintainers
+/package-lock.json     @TechForPalestine/maintainers
+/.npmrc                @TechForPalestine/maintainers
+
+# CI, Dependabot, and repo automation
+/.github/              @TechForPalestine/maintainers
+
+# Toolchain / runtime version pins
+/.nvmrc                @TechForPalestine/maintainers
+/devbox.json           @TechForPalestine/maintainers
+/devbox.lock           @TechForPalestine/maintainers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,23 +1,27 @@
 # Code owners — auto-requests review on matching paths.
 #
 # Dependency and CI-config changes (including Dependabot PRs) are routed to the
-# maintainer TEAM rather than any single person, so whoever is on the team is
-# added as a reviewer. Replace the team slug below with the real one on the
-# upstream org if it differs.
+# team that maintains THIS repository, so whoever maintains profile-pic-maker is
+# added as a reviewer — not the whole org.
+#
+# Replace the slug below with the real team that has maintain/admin on this repo.
+# (If no such team exists, an org owner can create one, e.g.
+# "profile-pic-maker-maintainers", and grant it Maintain on this repo. As a
+# stop-gap you may instead list individual maintainer usernames: `@alice @bob`.)
 #
 # NOTE: team ownership (`@org/team`) only resolves on a repo owned by that org.
 # On a personal-account fork it is inert — it takes effect once this file lands
 # on the TechForPalestine org repo.
 
 # Dependency manifests & lockfile
-/package.json          @TechForPalestine/maintainers
-/package-lock.json     @TechForPalestine/maintainers
-/.npmrc                @TechForPalestine/maintainers
+/package.json          @TechForPalestine/profile-pic-maker-maintainers
+/package-lock.json     @TechForPalestine/profile-pic-maker-maintainers
+/.npmrc                @TechForPalestine/profile-pic-maker-maintainers
 
 # CI, Dependabot, and repo automation
-/.github/              @TechForPalestine/maintainers
+/.github/              @TechForPalestine/profile-pic-maker-maintainers
 
 # Toolchain / runtime version pins
-/.nvmrc                @TechForPalestine/maintainers
-/devbox.json           @TechForPalestine/maintainers
-/devbox.lock           @TechForPalestine/maintainers
+/.nvmrc                @TechForPalestine/profile-pic-maker-maintainers
+/devbox.json           @TechForPalestine/profile-pic-maker-maintainers
+/devbox.lock           @TechForPalestine/profile-pic-maker-maintainers

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,32 +1,85 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for more information:
-# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-# https://containers.dev/guide/dependabot
-
+# Dependabot configuration.
+#
+# Strategy (see docs/dependency-updates.md for the full policy):
+#   - Routine patch/minor bumps are batched into a SINGLE monthly PR.
+#   - A 7-day cooldown gives new releases time to be yanked/patched before we
+#     adopt them (supply-chain soak). Real security advisories bypass this and
+#     open immediately as their own PRs.
+#   - Coordinated toolchains (React core, the ESLint stack) update as one PR.
+#   - Framework / standalone majors (next, tailwindcss, @types/node, ...) fall
+#     outside every group and open as individual PRs, reviewed as migration work.
+#   - Nothing auto-merges; a human reviews and merges every PR.
+#
+# Docs: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 version: 2
+
 updates:
-  # GitHub Actions updates
+  # ---------------------------------------------------------------------------
+  # GitHub Actions
+  # ---------------------------------------------------------------------------
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
-      interval: weekly
-    open-pull-requests-limit: 10
+      interval: monthly
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
+    labels:
+      - dependencies
+      - github-actions
+    commit-message:
+      prefix: "ci(deps)"
     groups:
-      all-actions:
+      github-actions:
         patterns:
           - "*"
 
-  # NPM updates
+  # ---------------------------------------------------------------------------
+  # npm
+  # ---------------------------------------------------------------------------
   - package-ecosystem: npm
     directory: "/"
     schedule:
-      interval: weekly
-    open-pull-requests-limit: 20
+      interval: monthly
+    open-pull-requests-limit: 10
+    # Supply-chain soak. Security updates are a separate channel and IGNORE this.
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+      semver-patch-days: 3
+    labels:
+      - dependencies
+    commit-message:
+      prefix: "build(deps)"
+      prefix-development: "build(deps-dev)"
+    # Group order matters: a dependency joins the FIRST group whose patterns
+    # match, so the specific coordinated groups are declared before `routine`.
     groups:
-      prod-patch-minor:
-        update-types: ["patch", "minor"]
-        dependency-type: "production"
-      dev-patch-minor:
-        update-types: ["patch", "minor"]
-        dependency-type: "development"
+      # React core must always move together (react + react-dom + their types),
+      # including majors — never split across PRs.
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"
+      # The ESLint 9 / typescript-eslint 8 flat-config migration as ONE PR.
+      eslint-stack:
+        patterns:
+          - "eslint"
+          - "eslint-config-next"
+          - "eslint-config-prettier"
+          - "eslint-plugin-prettier"
+          - "@typescript-eslint/*"
+      # Everything else: all remaining patch + minor bumps in a single PR.
+      # Majors of anything not captured above stay ungrouped -> individual PRs.
+      routine:
+        applies-to: version-updates
+        update-types:
+          - "patch"
+          - "minor"
+        patterns:
+          - "*"
+    # NOTE: security updates are deliberately left UNGROUPED so each CVE fix
+    # opens as its own fast, independent PR (a critical is never blocked behind
+    # a co-grouped low-severity fix) and is unaffected by the cooldown above.

--- a/docs/dependency-updates.md
+++ b/docs/dependency-updates.md
@@ -1,0 +1,111 @@
+# Dependency update policy
+
+How we keep dependencies current without drowning in review or getting burned by
+a bad release. This is the written contract behind
+[`.github/dependabot.yml`](../.github/dependabot.yml).
+
+## Goals
+
+- **Stay current** on security and routine fixes.
+- **Few, themed PRs** — routine bumps batch together; a human reviews and merges
+  every one (no auto-merge).
+- **Supply-chain safety** — a soak period before adopting a new release, so a
+  malicious or broken version that gets yanked within days never reaches us.
+- **Fast lane for real CVEs** — critical/high advisories are not made to wait.
+- **Deliberate majors** — breaking changes and deprecations are handled as
+  scheduled migration work, never rubber-stamped.
+
+## The three tiers
+
+| Tier | What | Cadence | Grouping | Cooldown | Who merges |
+|---|---|---|---|---|---|
+| **Routine** | patch + minor bumps | Monthly | One `routine` PR (plus `react` / `eslint-stack` when those are involved) | 7 days (3 for patch) | Human, after a skim + green CI |
+| **Security** | Dependabot security updates for published advisories | **Immediate** | Ungrouped — one PR per fix | **None** (bypasses soak) | Human, prioritised by CVSS; criticals same-day |
+| **Major** | major version bumps / deprecations needing code changes | As released | Coordinated toolchains grouped (`react`, `eslint-stack`); framework/standalone majors individual | 14 days | Human, as a migration PR |
+
+### Why cooldown *and* immediate security updates coexist
+
+Dependabot has two independent channels:
+
+- **Version updates** (driven by this config) — subject to the `cooldown`. This is
+  the supply-chain soak: if `some-lib@2.3.4` is compromised and yanked within a
+  week, the cooldown means we never opened a PR for it.
+- **Security updates** — triggered by a GitHub advisory, **ignore the schedule and
+  the cooldown** and open as soon as the advisory publishes. This is the CVSS 9/10
+  fast lane. They're left ungrouped so a critical fix is never blocked behind a
+  co-grouped low-severity one.
+
+> One-time enablement (GitHub Settings, not this file): turn on **Dependabot
+> alerts** and **Dependabot security updates** under
+> *Settings → Advanced Security* (or org policy). The security fast lane does not
+> exist until these are on.
+
+## Grouping (how the pile-up shrinks)
+
+Groups are matched top-to-bottom; a dependency joins the **first** group it
+matches, so specific groups are declared before the catch-all `routine`:
+
+- **`react`** — `react`, `react-dom`, `@types/react`, `@types/react-dom` move as
+  one PR (all update types). They must never be split — a react/react-dom version
+  skew breaks the build.
+- **`eslint-stack`** — `eslint`, `eslint-config-next`, `@typescript-eslint/*`,
+  and the prettier eslint plugins. The ESLint 9 / typescript-eslint 8 flat-config
+  migration is one coordinated PR, not five.
+- **`routine`** — every remaining **patch/minor** bump, in a single monthly PR.
+- **Ungrouped** — a **major** of anything not in `react`/`eslint-stack`
+  (`next`, `tailwindcss`, `@types/node`, `dayjs`, …) opens as its own PR, because
+  each is a focused migration.
+
+Worked example — the 10 stale upstream PRs collapse to ~6 themed ones:
+
+| Today (individual) | Becomes |
+|---|---|
+| react-icons minor, dev-patch-minor group | **`routine`** (1 PR) |
+| `react` + `react-dom` + their types (2 PRs) | **`react`** (1 PR) |
+| ts-eslint parser + plugin + eslint-config-next (3 PRs) | **`eslint-stack`** (1 PR) |
+| `next` 14→16 | individual major (1 PR) |
+| `tailwindcss` 3→4 | individual major (1 PR) |
+| `@types/node` 24→25 | individual major (1 PR) |
+
+## Handling the existing stale Dependabot PRs (run on the upstream repo)
+
+Do this **after** the new `.github/dependabot.yml` lands on upstream:
+
+1. **Merge or close the trivial routine ones first** (e.g. the react-icons minor
+   and the dev-patch-minor group). The new `routine` group regenerates anything
+   still outstanding cleanly on the next run.
+2. **Close the split majors** so Dependabot recreates them grouped:
+   - the two React PRs → reopen as one **`react`** PR;
+   - the three ESLint/ts-eslint PRs → reopen as one **`eslint-stack`** PR.
+   Either wait for the next scheduled run or comment `@dependabot recreate`.
+3. **Keep the framework/standalone majors as deliberate migrations:**
+   - `next` **14 → 16** is *two* majors — do 14→15, then 15→16, not one jump.
+   - `tailwindcss` **3 → 4** is a config-format rewrite — own PR, own testing.
+   - `@types/node` major — small, but verify build/types.
+4. From then on the steady state is: one monthly `routine` PR, immediate security
+   PRs, and the occasional grouped/individual major.
+
+## Future flow (steady state)
+
+- **Monthly:** a `routine` PR appears → glance at the changelog links → CI green →
+  merge.
+- **On advisory:** a security PR appears immediately → check CVSS → criticals
+  merged same-day, others within the sprint.
+- **On a major:** a grouped (`react` / `eslint-stack`) or individual PR appears →
+  scheduled as migration work → read release notes for deprecations/breaking
+  changes → apply required code changes in the same PR → merge when green.
+
+## Known caveats for reviewers
+
+- **`.npmrc` has `legacy-peer-deps=true`.** Installs succeed even when peer ranges
+  conflict, so a major bump (e.g. React 19, Next 15+) can install cleanly yet be
+  subtly incompatible. During **major** reviews, check peer ranges by hand — don't
+  rely on `npm ci` to surface the mismatch.
+- **CI runs live third-party tests (`api.fxtwitter.com`, Twitter CDN) on the
+  required path.** A dependency PR can go red from an upstream outage, not the
+  bump. Two retries are configured; if it's clearly a transient network failure,
+  re-run the job or comment `@dependabot recreate`.
+- **Test coverage is Twitter-only.** The GitHub/GitLab/Bluesky/`gaza-status`/
+  upload paths are not exercised, so the safety net is thinner for changes that
+  touch those areas — review such bumps more carefully. Widening coverage is the
+  highest-leverage way to make future updates safer to merge.


### PR DESCRIPTION
This pull request refines and documents the repository’s dependency update process. It introduces a comprehensive policy for Dependabot updates, configures grouping and cooldown strategies for dependency PRs, and establishes code ownership for key files. These changes aim to reduce review noise, improve supply-chain safety, and ensure all updates are reviewed by the appropriate maintainers.

**Dependency update policy and configuration:**

* Added `docs/dependency-updates.md` to document the new dependency update policy, detailing goals, grouping, cooldowns, and the process for handling security/major updates.
* Overhauled `.github/dependabot.yml`:
  - Groups routine dependency updates into themed monthly PRs (e.g., `react`, `eslint-stack`, and a catch-all `routine`) to reduce PR noise.
  - Introduces cooldown periods (7 days for most, 3 for patches, 14 for majors) before non-security updates, while security advisories open immediately and ungrouped.
  - Sets commit message prefixes and labels for clarity and tracking.

**Code ownership and review routing:**

* Added `.github/CODEOWNERS` to auto-request reviews for dependency and CI/config changes, with instructions for transitioning ownership from a personal fork to the organization’s maintainer team.