### PR TITLE
fix: resolve top Sentry issues (PPM-4, PPM-A, PPM-8)

### DIFF
--- a/src/app/dom-safety.tsx
+++ b/src/app/dom-safety.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+/**
+ * Guards against a class of React crashes that surface in Sentry as:
+ *   "NotFoundError: Failed to execute 'removeChild' on 'Node': The node to be
+ *    removed is not a child of this node." (Sentry PPM-4)
+ *
+ * These fire when a browser translation feature (Google Translate, or the
+ * auto-translate built into mobile Chrome / in-app browsers) or a similar
+ * extension mutates the text nodes React is tracking. When React later commits
+ * an update and tries to remove or reinsert one of those nodes, its parent has
+ * already changed underneath it, so the raw DOM call throws and unmounts the
+ * whole app.
+ *
+ * The mitigation — recommended in https://github.com/facebook/react/issues/11538
+ * — is to make removeChild and insertBefore no-op in exactly the case that
+ * would otherwise throw (the node is no longer under the expected parent),
+ * which keeps the React tree alive. We only intercept the throwing case, so
+ * well-formed DOM operations are unaffected.
+ *
+ * The patch is applied at module-evaluation time (guarded so it is a no-op
+ * during server rendering, where `Node` is undefined) rather than in an effect,
+ * so it is in place before React commits any updates on the client.
+ */
+if (typeof Node !== 'undefined' && Node.prototype) {
+  const originalRemoveChild = Node.prototype.removeChild;
+  Node.prototype.removeChild = function removeChild<T extends Node>(
+    this: Node,
+    child: T,
+  ): T {
+    if (child.parentNode !== this) {
+      if (typeof console !== 'undefined') {
+        console.warn(
+          'Skipped removeChild for a node whose parent has changed (likely browser translation).',
+          child,
+        );
+      }
+      return child;
+    }
+    return originalRemoveChild.call(this, child) as T;
+  };
+
+  const originalInsertBefore = Node.prototype.insertBefore;
+  Node.prototype.insertBefore = function insertBefore<T extends Node>(
+    this: Node,
+    newNode: T,
+    referenceNode: Node | null,
+  ): T {
+    if (referenceNode && referenceNode.parentNode !== this) {
+      if (typeof console !== 'undefined') {
+        console.warn(
+          'Skipped insertBefore for a reference node whose parent has changed (likely browser translation).',
+          referenceNode,
+        );
+      }
+      return newNode;
+    }
+    return originalInsertBefore.call(this, newNode, referenceNode) as T;
+  };
+}
+
+/**
+ * Renders nothing. Importing/mounting this component pulls in the DOM-safety
+ * patch above on the client.
+ */
+export default function DomSafety() {
+  return null;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Inter } from 'next/font/google';
 import Script from 'next/script';
 
 import './globals.css';
+import DomSafety from './dom-safety';
 
 const inter = Inter({ subsets: ['latin'] });
 
@@ -27,6 +28,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={inter.className}>
+        <DomSafety />
         {children}
         {/* Privacy-friendly analytics by Plausible */}
         <Script

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -49,8 +49,14 @@ export default function Home() {
 
   useEffect(() => {
     fetch('/api/gaza-status')
-      .then((res) => res.json())
-      .then((data) => setGazaStatusSummary(data.summary));
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => setGazaStatusSummary(data?.summary))
+      .catch((error) => {
+        // The Gaza status banner is non-essential. Swallow network failures
+        // here so they don't bubble up as an unhandled "Failed to fetch" /
+        // "Load failed" rejection (Sentry PPM-8 / PPM-A).
+        console.error('Error fetching Gaza status summary:', error);
+      });
   }, []);
 
   const handleImageUpload = (e: React.ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
## Summary

Fixes the top Sentry issues in the **ppm** project (Tech For Palestine), taken from the highest-volume unresolved errors. These three issues account for ~70% of all captured error events (55 of 78).

Each fix is in its own commit.

## Fixes

### 1. `PPM-4` — React `removeChild` crash (46 events, the Top 1 issue)
`NotFoundError: Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.`

The classic React + browser-translation conflict. Google Translate / mobile-Chrome & in-app-browser auto-translate replace the text nodes React is tracking; when React later removes or reinserts one, its parent has changed and the raw DOM call throws, crashing the whole app. Affected events are overwhelmingly non-English locales (Tunisia, Belgium, Germany, India) where auto-translate triggers.

**Fix:** a small client-only `DomSafety` patch (mounted from the root layout) that makes `Node.prototype.removeChild` / `insertBefore` no-op *only* in the case that would otherwise throw. Well-formed DOM operations are untouched. See [facebook/react#11538](https://github.com/facebook/react/issues/11538).

### 2. `PPM-A` + `PPM-8` — unhandled fetch rejection (6 + 3 events)
`TypeError: Load failed` (Safari) / `TypeError: Failed to fetch` (Chrome), both via `onunhandledrejection`.

The `/api/gaza-status` fetch on the landing page had no error handling (`fetch().then(res => res.json()).then(...)`). A failed request (offline, ad-blocker, in-app browser, flaky network) became an unhandled promise rejection. Confirmed via matching app frame in `page.js` — it's the only bare `fetch` without a `.catch()`.

**Fix:** add a `.catch()` and guard against a non-ok response. The banner it feeds is non-essential, so failures now degrade silently.

## Out of scope (deliberately not fixed here)
- **PPM-5** (`Maximum call stack size exceeded`) — stack is `undefined:31:70` with no app frames; not confidently attributable to our code (likely an extension/injected script).
- **PPM-6** (`NotFoundError: The object can not be found here.`) — ambiguous DOM error; may be mitigated by the PPM-4 patch but not verified.
- **PPM-9 / PPM-7 / PPM-B** (`window.webkit.messageHandlers`, `Java object is gone`) — in-app-browser (WKWebView / Android WebView) injected-script noise, not our code. Better addressed via Sentry `ignoreErrors` filtering than a code change.

## Verification
- `npm run lint` — 0 errors (1 pre-existing `<img>` warning, unrelated)
- `tsc --noEmit` — clean
- `npm run build` — compiles, `/` prerenders (confirms the SSR `Node` guard)
- `npm test` — 3/3 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)